### PR TITLE
Migrate usages of deprecated `JavaInfo` fields

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -261,7 +261,7 @@ def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps):
     )
 
     # For sandboxing to work, and for this action to be deterministic, the compile jars need to be passed as inputs
-    inputs = depset(jdeps, transitive = [depset([], transitive = [dep.transitive_deps for dep in deps])])
+    inputs = depset(jdeps, transitive = [depset([], transitive = [dep.transitive_compile_time_jars for dep in deps])])
 
     ctx.actions.run(
         mnemonic = mnemonic,


### PR DESCRIPTION
`transitive_deps` was an alias for `transitive_compile_time_jars` `transitive_runtime_deps` was an alias for `transitive_runtime_jars`

The fields were deprecated in 2021, and are dropped in Bazel@HEAD

Fixes https://github.com/bazelbuild/rules_kotlin/issues/1003